### PR TITLE
Monthly Summary Updates

### DIFF
--- a/monthly-report.sql
+++ b/monthly-report.sql
@@ -42,6 +42,80 @@ GROUP BY 1
 ORDER BY 1 ASC
 ;
 
+-- Highs and Lows
+\set QUIET 1
+\x on
+\set QUIET 0
+WITH stats AS (
+        SELECT
+        date_trunc('day', (data ->> 'time')::timestamptz)::date AS "Outdoor",
+        MAX(((data -> 'fields') -> 'temperature_F')::numeric) AS "High"
+        FROM weather
+        WHERE
+        (data ->> 'measurement') LIKE '%3n1%'
+        AND
+        (data ->> 'time')::timestamptz BETWEEN date_trunc('month', current_date - interval '1 month') and date_trunc('month', current_date)
+        GROUP BY 1
+        HAVING MAX(((data -> 'fields') -> 'temperature_F')::numeric) > 89
+        ORDER BY 1 ASC
+)
+SELECT
+COUNT(*) AS "Days above 90"
+FROM stats
+;
+\set QUIET 1
+\x off
+\set QUIET 0
+SELECT
+date_trunc('day', (data ->> 'time')::timestamptz)::date AS "Outdoor",
+MAX(((data -> 'fields') -> 'temperature_F')::numeric) AS "High"
+FROM weather
+WHERE
+(data ->> 'measurement') LIKE '%3n1%'
+AND
+(data ->> 'time')::timestamptz BETWEEN date_trunc('month', current_date - interval '1 month') and date_trunc('month', current_date)
+GROUP BY 1
+HAVING MAX(((data -> 'fields') -> 'temperature_F')::numeric) > 89
+ORDER BY 1 ASC
+;
+
+\set QUIET 1
+\x on
+\set QUIET 0
+WITH stats AS (
+        SELECT
+        date_trunc('day', (data ->> 'time')::timestamptz)::date AS "Outdoor",
+        MIN(((data -> 'fields') -> 'temperature_F')::numeric) AS "Low"
+        FROM weather
+        WHERE
+        (data ->> 'measurement') LIKE '%3n1%'
+        AND
+        (data ->> 'time')::timestamptz BETWEEN date_trunc('month', current_date - interval '1 month') and date_trunc('month', current_date)
+        GROUP BY 1
+        HAVING MIN(((data -> 'fields') -> 'temperature_F')::numeric) < 33
+        ORDER BY 1 ASC
+)
+SELECT
+COUNT(*) AS "Days below freezing"
+FROM stats
+;
+\set QUIET 1
+\x off
+\set QUIET 0
+SELECT
+date_trunc('day', (data ->> 'time')::timestamptz)::date AS "Outdoor",
+MIN(((data -> 'fields') -> 'temperature_F')::numeric) AS "Low"
+FROM weather
+WHERE
+(data ->> 'measurement') LIKE '%3n1%'
+AND
+(data ->> 'time')::timestamptz BETWEEN date_trunc('month', current_date - interval '1 month') and date_trunc('month', current_date)
+GROUP BY 1
+HAVING MIN(((data -> 'fields') -> 'temperature_F')::numeric) < 33
+ORDER BY 1 ASC
+;
+
+
 -- Living Room stats
 \set QUIET 1
 \x on

--- a/weather-maint.sql
+++ b/weather-maint.sql
@@ -48,9 +48,13 @@ RENAME TO weather;
 ALTER SEQUENCE weather_id_seq OWNED BY weather.id;
 
 -- Fix the permissions
-GRANT ALL ON TABLE weather TO superuser-account;
-GRANT SELECT ON TABLE weather TO grafana-account;
-GRANT INSERT ON TABLE weather TO remote-account;
+GRANT ALL ON TABLE weather TO tom;
+GRANT SELECT ON TABLE weather TO grafana;
+GRANT INSERT ON TABLE weather TO swartzremote;
 
--- Optionally drop the table automatically
+-- Get latest stats now that the big change has happened
+ANALYZE weather;
+
+-- Optionally drop the table automatically and clear up data
 --DROP TABLE weather_old;
+--VACUUM (FULL, FREEZE, ANALYZE)


### PR DESCRIPTION
Update monthly summary to add highs and lows

- Provides count of >90°F (±1°F precision) days
- Provides dates and high temperatures, if exist
- Provides count of <32°F  (±1°F precision) days
- Provides dates and low temps, if exist